### PR TITLE
Allow for custom colors!

### DIFF
--- a/TGCameraViewController/Control/TGCameraNavigationController.h
+++ b/TGCameraViewController/Control/TGCameraNavigationController.h
@@ -28,23 +28,24 @@
 
 @interface TGCameraNavigationController : UINavigationController
 
-// fucking shit fuck you swift fuck.  Have to comment these out otherwise I cant subclass (cz)
++ (instancetype)new __attribute__
+((unavailable("[+new] is not allowed, use [+newWithCameraDelegate:]")));
 
-//+ (instancetype)new;
-//
-//- (instancetype) init;
-//
-//- (id)initWithCoder:(NSCoder *)aDecoder;
+- (instancetype) init __attribute__
+((unavailable("[-init] is not allowed, use [+newWithCameraDelegate:]")));
 
-//- (instancetype)initWithNavigationBarClass:(Class)navigationBarClass toolbarClass:(Class)toolbarClass __attribute__
-//((unavailable("[-initWithNavigationBarClass:toolbarClass:] is not allowed, use [+newWithCameraDelegate:]")));
-//
-//- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil __attribute__
-//((unavailable("[-initWithNibName:bundle:] is not allowed, use [+newWithCameraDelegate:]")));
-//
-//- (instancetype)initWithRootViewController:(UIViewController *)rootViewController __attribute__
-//((unavailable("[-initWithRootViewController:] is not allowed, use [+newWithCameraDelegate:]")));
+- (id)initWithCoder:(NSCoder *)aDecoder __attribute__
+((unavailable("[-initWithCoder:] is not allowed, use [+newWithCameraDelegate:]")));
 
-+ (instancetype)newWithCameraDelegate:(id<TGCameraDelegate>)delegate ;
+- (instancetype)initWithNavigationBarClass:(Class)navigationBarClass toolbarClass:(Class)toolbarClass __attribute__
+((unavailable("[-initWithNavigationBarClass:toolbarClass:] is not allowed, use [+newWithCameraDelegate:]")));
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil __attribute__
+((unavailable("[-initWithNibName:bundle:] is not allowed, use [+newWithCameraDelegate:]")));
+
+- (instancetype)initWithRootViewController:(UIViewController *)rootViewController __attribute__
+((unavailable("[-initWithRootViewController:] is not allowed, use [+newWithCameraDelegate:]")));
+
++ (instancetype)newWithCameraDelegate:(id<TGCameraDelegate>)delegate;
 
 @end


### PR DESCRIPTION
Don't feel obligated to merge this, but I wrote the code so I figured I'd share it if anyone else wants to use it.  It's *fairly* clean, but it's definitely not a perfect solution.  I attempted to leave as little footprint as possible, so I left all of the images the same color and changed each button's renderingMode to `UIImageRenderingModeAlwaysTemplate` to take on the tintColor of the button.

## Detailed summary of changes
* Removed `+ (UIColor *)orangeColor` and replaced it with `+ (UIColor *)tintColor` in `TGCameraColor.m`
* Exposed `+ (UIColor *)tintColor` and `+ (void)setTintColor:(UIColor*)tintColor` in `TGCameraColor.h`
* Created `TGTintedButton` class which tints the images and backgroundImages using `[TGCameraColor tintColor]`, assuming `customTintColorOverride` has not been set.
* Created `TGTintedLabel` which sets the text color to `[TGCameraColor tintColor]`
* Changed the `UIButtons` in the xibs to `TGTintedButtons`
* Changed the `UILabels` in `TGCameraAuthorizationViewController.xib` to `TGTintedLabels`
* Deleted `CameraConfirm.imageset` and changed the image of the confirm button to `CameraShot`<sup>1</sup>
* Created `CameraCheckMark.imageset` and created a `UIImageView` that sits above the confirm button in `TGPhotoViewController.xib` and added the appropriate constraints<sup>1</sup>
* Added `TintColorFromAVCaptureFlashMode` and set `customTintColorOverride` of the flash to be gray when it is "off", and the default tint color when it is "on" or "auto".
* Set the tintColor in `TGInitialViewController.m`

## Usage
Call this method before creating the `TGCameraNavigationController`.  You can call it after, but you have to make sure to invalidate all of the tintable buttons and labels.
```objc
[TGCameraColor setTintColor: [UIColor greenColor]];
```

## Screenshots
![image](https://cloud.githubusercontent.com/assets/1509815/6909505/a72101e6-d6fb-11e4-9ac0-d8e380330e48.png)
![image](https://cloud.githubusercontent.com/assets/1509815/6909519/c9ad0818-d6fb-11e4-9cc5-da9a8f4d6377.png)
![image](https://cloud.githubusercontent.com/assets/1509815/6909521/d2059354-d6fb-11e4-8063-8937fc020bf1.png)
![image](https://cloud.githubusercontent.com/assets/1509815/6909524/e4585b2c-d6fb-11e4-8395-09bc94332ea5.png)

## Footnotes
[1] - The image tinting mechanism works by setting the image's renderingMode to `UIImageRenderingModeAlwaysTemplate`.  This changes anything in the image that isn't transparent to the tint color.  Since `CameraConfirm.imageset` has a white checkmark (not transparent), when the image gets tinted it looks the exact same as `CameraShot.imageset`.  To get around this, I put the checkmark on a transparent background (`CameraCheckMark.imageset`), set the confirm button's image to `CameraShot.imageset`, and placed an image view with the check mark centered on the button.  This has the caveat that the checkmark does **not** dim when the button is selected.  This obviously isn't ideal, but it works well enough :)

Feel free to respond with any questions / suggestions.