### PR TITLE
Control Show/Hide Filter and Album

### DIFF
--- a/Example/Classes/Control/TGInitialViewController.m
+++ b/Example/Classes/Control/TGInitialViewController.m
@@ -85,6 +85,10 @@
     NSLog(@"%s error: %@", __PRETTY_FUNCTION__, error);
 }
 
+- (BOOL)cameraFilterViewEnabled {
+    return true;
+}
+
 #pragma mark -
 #pragma mark - Actions
 

--- a/Example/Classes/Control/TGInitialViewController.m
+++ b/Example/Classes/Control/TGInitialViewController.m
@@ -32,6 +32,9 @@
     [TGCamera setOption:kTGCameraOptionSaveImageToAlbum value:[NSNumber numberWithBool:YES]];
     //[TGCamera setOption:kTGCameraOptionHiddenToggleButton value:[NSNumber numberWithBool:YES]];
     //[TGCameraColor setTintColor: [UIColor greenColor]];
+    [TGCamera setOption:kTGCameraOptionHiddenAlbumButton value:[NSNumber numberWithBool:NO]];
+    [TGCamera setOption:kTGCameraOptionHiddenFilterButton value:[NSNumber numberWithBool:NO]];
+
     
     _photoView.clipsToBounds = YES;
     
@@ -83,10 +86,6 @@
 - (void)cameraDidSavePhotoWithError:(NSError *)error
 {
     NSLog(@"%s error: %@", __PRETTY_FUNCTION__, error);
-}
-
-- (BOOL)cameraFilterViewEnabled {
-    return true;
 }
 
 #pragma mark -

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
 |Option|Type|Default|Description|
 |:-:|:-:|:-:|:-:|
 |kTGCameraOptionHiddenToggleButton|NSNumber (YES/NO)|NO|Displays or hides the button that switches between the front and rear camera|
+|kTGCameraOptionHiddenAlbumButton|NSNumber (YES/NO)|NO|Displays or hides the button that allows the user to select a photo from his/her album|
+|kTGCameraOptionHiddenFilterButton|NSNumber (YES/NO)|NO|Displays or hides the button that allos the user to filter his/her photo|
 |kTGCameraOptionSaveImageToAlbum|NSNumber (YES/NO)|NO|Save or not the photo in the camera roll|
 
 ```obj-c

--- a/TGCameraViewController/Classes/Control/TGCameraViewController.m
+++ b/TGCameraViewController/Classes/Control/TGCameraViewController.m
@@ -84,8 +84,13 @@
         _toggleButtonWidth.constant = 0;
     }
     
+    if ([[TGCamera getOption:kTGCameraOptionHiddenAlbumButton] boolValue] == YES) {
+        _albumButton.hidden = YES;
+    }
+    
     [_albumButton.layer setCornerRadius:10.f];
     [_albumButton.layer setMasksToBounds:YES];
+    
     
     _camera = [TGCamera cameraWithFlashButton:_flashButton];
     
@@ -146,10 +151,10 @@
         _albumButton.enabled =
         _flashButton.enabled = YES;
     }];
-     
+    
     if (_wasLoaded == NO) {
         _wasLoaded = YES;
-       [_camera insertSublayerWithCaptureView:_captureView atRootView:self.view];
+        [_camera insertSublayerWithCaptureView:_captureView atRootView:self.view];
     }
     
     // get the latest image from the album
@@ -247,10 +252,10 @@
     
     [self viewWillDisappearWithCompletion:^{
         [_camera takePhotoWithCaptureView:_captureView videoOrientation:videoOrientation cropSize:_captureView.frame.size
-        completion:^(UIImage *photo) {
-            TGPhotoViewController *viewController = [TGPhotoViewController newWithDelegate:_delegate photo:photo];
-            [self.navigationController pushViewController:viewController animated:YES];
-        }];
+                               completion:^(UIImage *photo) {
+                                   TGPhotoViewController *viewController = [TGPhotoViewController newWithDelegate:_delegate photo:photo];
+                                   [self.navigationController pushViewController:viewController animated:YES];
+                               }];
     }];
 }
 

--- a/TGCameraViewController/Classes/Control/TGPhotoViewController.m
+++ b/TGCameraViewController/Classes/Control/TGPhotoViewController.m
@@ -29,6 +29,7 @@
 #import "TGCameraColor.h"
 #import "TGCameraFilterView.h"
 #import "UIImage+CameraFilters.h"
+#import "TGTintedButton.h"
 
 static NSString* const kTGCacheSatureKey = @"TGCacheSatureKey";
 static NSString* const kTGCacheCurveKey = @"TGCacheCurveKey";
@@ -42,6 +43,7 @@ static NSString* const kTGCacheVignetteKey = @"TGCacheVignetteKey";
 @property (strong, nonatomic) IBOutlet UIView *bottomView;
 @property (strong, nonatomic) IBOutlet TGCameraFilterView *filterView;
 @property (strong, nonatomic) IBOutlet UIButton *defaultFilterButton;
+@property (weak, nonatomic) IBOutlet TGTintedButton *filterWandButton;
 
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *topViewHeight;
 
@@ -92,6 +94,13 @@ static NSString* const kTGCacheVignetteKey = @"TGCacheVignetteKey";
     
     _photoView.clipsToBounds = YES;
     _photoView.image = _photo;
+    
+    if (self.delegate != nil) {
+        if ([self.delegate respondsToSelector: @selector(cameraFilterViewEnabled)]) {
+            self.filterWandButton.enabled = [self.delegate cameraFilterViewEnabled];
+            self.filterWandButton.hidden = ![self.delegate cameraFilterViewEnabled];
+        }
+    }
     
     [self addDetailViewToButton:_defaultFilterButton];
 }

--- a/TGCameraViewController/Classes/Control/TGPhotoViewController.m
+++ b/TGCameraViewController/Classes/Control/TGPhotoViewController.m
@@ -95,11 +95,8 @@ static NSString* const kTGCacheVignetteKey = @"TGCacheVignetteKey";
     _photoView.clipsToBounds = YES;
     _photoView.image = _photo;
     
-    if (self.delegate != nil) {
-        if ([self.delegate respondsToSelector: @selector(cameraFilterViewEnabled)]) {
-            self.filterWandButton.enabled = [self.delegate cameraFilterViewEnabled];
-            self.filterWandButton.hidden = ![self.delegate cameraFilterViewEnabled];
-        }
+    if ([[TGCamera getOption:kTGCameraOptionHiddenFilterButton] boolValue] == YES) {
+        _filterWandButton.hidden = YES;
     }
     
     [self addDetailViewToButton:_defaultFilterButton];

--- a/TGCameraViewController/Classes/Helper/TGCamera.h
+++ b/TGCameraViewController/Classes/Helper/TGCamera.h
@@ -29,6 +29,8 @@
 
 
 #define kTGCameraOptionHiddenToggleButton @"TGCameraOptionHiddenToggleButton"
+#define kTGCameraOptionHiddenAlbumButton @"TGCameraOptionHiddenAlbumButton"
+#define kTGCameraOptionHiddenFilterButton @"TGCameraOptionHiddenFilterButton"
 #define kTGCameraOptionSaveImageToAlbum @"TGCameraOptionSaveImageToAlbum"
 
 @protocol TGCameraDelegate;
@@ -85,6 +87,5 @@
 - (void)cameraDidSavePhotoWithError:(NSError *)error;
 - (void)cameraDidSavePhotoAtPath:(NSURL *)assetURL;
 - (void)cameraWillTakePhoto;
-- (BOOL)cameraFilterViewEnabled;
 
 @end

--- a/TGCameraViewController/Classes/Helper/TGCamera.h
+++ b/TGCameraViewController/Classes/Helper/TGCamera.h
@@ -85,6 +85,6 @@
 - (void)cameraDidSavePhotoWithError:(NSError *)error;
 - (void)cameraDidSavePhotoAtPath:(NSURL *)assetURL;
 - (void)cameraWillTakePhoto;
-
+- (BOOL)cameraFilterViewEnabled;
 
 @end

--- a/TGCameraViewController/Classes/View/Base.lproj/TGPhotoViewController.xib
+++ b/TGCameraViewController/Classes/View/Base.lproj/TGPhotoViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E36b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
@@ -11,6 +11,7 @@
                 <outlet property="bottomView" destination="Wwe-hD-eWO" id="phi-0I-kq7"/>
                 <outlet property="defaultFilterButton" destination="9jP-uX-c4U" id="AEq-cV-Ah8"/>
                 <outlet property="filterView" destination="mfq-V7-07J" id="Pf2-0x-IU7"/>
+                <outlet property="filterWandButton" destination="bwi-ED-cl6" id="g4M-yf-0ho"/>
                 <outlet property="photoView" destination="AgS-wg-ici" id="7RM-EQ-xh7"/>
                 <outlet property="topViewHeight" destination="tVK-li-H3V" id="3hD-FB-P1W"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>


### PR DESCRIPTION
I added two options: kTGCameraOptionHiddenFilterButton & kTGCameraOptionHiddenAlbumButton. The first hides the wand on the photo view controller and the second hides the album button, disabling the user's access to choosing a photo from their album. If nothing is changed, both of these default to NO, which means nothing changes for current users of this repo.