### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/LCT-TGCameraViewController.podspec
+++ b/LCT-TGCameraViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
-  s.name = 'TGCameraViewController'
-  s.version = '2.2.1'
+  s.name = 'LCT-TGCameraViewController'
+  s.version = '2.2.2'
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   s.summary = 'Custom camera with AVFoundation. Beautiful, light and easy to integrate with iOS projects.'
   s.homepage = 'https://github.com/tdginternet/TGCameraViewController'
@@ -10,10 +10,10 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.ios.deployment_target = '7.0'
   
-  s.authors = { 'Bruno Tortato Furtado' => 'bruno@furtado.me' }
+  s.authors = { 'Bruno Tortato Furtado' => 'bruno@furtado.me', 'Eddie Li' => 'eli@sandsmedia.com' }
   
   s.ios.frameworks = 'AssetsLibrary', 'AVFoundation', 'CoreImage', 'Foundation', 'MobileCoreServices', 'UIKit'
   s.source_files = 'TGCameraViewController/**/*.{h,m}'
   s.resources = ['TGCameraViewController/**/*.xib', 'TGCameraViewController/**/*.xcassets', 'TGCameraViewController/Resources/TGCameraViewController.bundle']
-  s.source = { :git => 'https://github.com/tdginternet/TGCameraViewController.git', :tag => s.version }  
+  s.source = { :git => 'https://github.com/eddielisands/TGCameraViewController.git', :tag => s.version }  
 end

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Custom camera with AVFoundation. Beautiful, light and easy to integrate with iOS
 
 [![Build Status](https://api.travis-ci.org/tdginternet/TGCameraViewController.png)](https://api.travis-ci.org/tdginternet/TGCameraViewController.png)&nbsp;
 ![License MIT](https://go-shields.herokuapp.com/license-MIT-blue.png)&nbsp;
-[![Cocoapods](http://img.shields.io/cocoapods/v/TGCameraViewController.svg)](http://cocoapods.org/?q=on%3Aios%20tgcameraviewcontroller)&nbsp;
-[![Cocoapods](http://img.shields.io/cocoapods/p/TGCameraViewController.svg)](http://cocoapods.org/?q=on%3Aios%20tgcameraviewcontroller)&nbsp;
+[![CocoaPods](http://img.shields.io/cocoapods/v/TGCameraViewController.svg)](http://cocoapods.org/?q=on%3Aios%20tgcameraviewcontroller)&nbsp;
+[![CocoaPods](http://img.shields.io/cocoapods/p/TGCameraViewController.svg)](http://cocoapods.org/?q=on%3Aios%20tgcameraviewcontroller)&nbsp;
 [![Analytics](https://ga-beacon.appspot.com/UA-54929747-1/tdginternet/TGCameraViewController/README.md)](https://github.com/igrigorik/ga-beacon)
 
 * Completely custom camera with AVFoundation

--- a/TGCameraViewController/Classes/UI/TGTintedButton.m
+++ b/TGCameraViewController/Classes/UI/TGTintedButton.m
@@ -49,10 +49,10 @@
     if(self.tintColor != color) {
         [self setTintColor:color];
         
-        UIImage * __weak backgroundImage = [[self backgroundImageForState:UIControlStateNormal] imageWithRenderingMode:renderingMode];
+        UIImage *backgroundImage = [[self backgroundImageForState:UIControlStateNormal] imageWithRenderingMode:renderingMode];
         [self setBackgroundImage:backgroundImage forState:UIControlStateNormal];
         
-        UIImage * __weak image = [[self imageForState:UIControlStateNormal] imageWithRenderingMode:renderingMode];
+        UIImage *image = [[self imageForState:UIControlStateNormal] imageWithRenderingMode:renderingMode];
         [self setImage:image forState:UIControlStateNormal];
         
     }


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
