### PR TITLE
Refactored saveJPGImageAtDocumentDirectory:image:resultBlock:failureBlock

### DIFF
--- a/TGCameraViewController/Classes/Helper/TGAssetsLibrary.m
+++ b/TGCameraViewController/Classes/Helper/TGAssetsLibrary.m
@@ -209,7 +209,7 @@
 	[path appendString: documentPath.path];
 	[path appendString:@"/Images/"];
 	
-	if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+	if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
 		NSError *error;
 		[[NSFileManager defaultManager] createDirectoryAtPath:path withIntermediateDirectories:NO attributes:nil error:&error];
 		

--- a/TGCameraViewController/Classes/Helper/TGAssetsLibrary.m
+++ b/TGCameraViewController/Classes/Helper/TGAssetsLibrary.m
@@ -138,30 +138,35 @@
 
 - (void)saveJPGImageAtDocumentDirectory:(UIImage *)image resultBlock:(TGAssetsResultCompletion)resultBlock failureBlock:(TGAssetsFailureCompletion)failureBlock
 {
-    NSDateFormatter *dateFormatter = [NSDateFormatter new];
-    [dateFormatter setDateFormat:@"yyyy-MM-dd_HH:mm:SSSSZ"];
-    
-    NSString *directory = [self directory];
-    
-    if (!directory) {
-        failureBlock(nil);
-        return;
-    }
-    
-    NSString *fileName = [[dateFormatter stringFromDate:[NSDate date]] stringByAppendingPathExtension:@"jpg"];
-    NSString *filePath = [directory stringByAppendingString:fileName];
-    
-    if (filePath == nil) {
-        failureBlock(nil);
-        return;
-    }
-    
-    NSData *data = UIImageJPEGRepresentation(image, 1);
-    [data writeToFile:filePath atomically:YES];
-    
-    NSURL *assetURL = [NSURL URLWithString:filePath];
-    
-    resultBlock(assetURL);
+	NSFileManager *fileManager = [NSFileManager defaultManager];
+	NSDateFormatter *dateFormatter = [NSDateFormatter new];
+	[dateFormatter setDateFormat:@"yyyy-MM-dd_HH:mm:SSSSZ"];
+	
+	NSString *directory = [self directory];
+	
+	if (!directory) {
+		failureBlock(nil);
+		return;
+	}
+	
+	NSString *fileName = [[dateFormatter stringFromDate:[NSDate date]] stringByAppendingPathExtension:@"jpg"];
+	NSString *filePath = [directory stringByAppendingString:fileName];
+	
+	if (filePath == nil) {
+		failureBlock(nil);
+		return;
+	}
+	
+	NSData *data = UIImageJPEGRepresentation(image, 1);
+	
+	if (![fileManager createFileAtPath:filePath contents:data attributes:nil]) {
+		failureBlock(nil);
+		return;
+	}
+	
+	NSURL *assetURL = [NSURL URLWithString: filePath];
+	
+	resultBlock(assetURL);
 }
 
 #pragma mark -

--- a/TGCameraViewController/Classes/Helper/TGAssetsLibrary.m
+++ b/TGCameraViewController/Classes/Helper/TGAssetsLibrary.m
@@ -204,20 +204,21 @@
 
 - (NSString *)directory
 {
-    NSMutableString *path = [NSMutableString new];
-    [path appendString:[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject]];
-    [path appendString:@"/Images/"];
-    
-    if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
-        NSError *error;
-        [[NSFileManager defaultManager] createDirectoryAtPath:path withIntermediateDirectories:NO attributes:nil error:&error];
-        
-        if (error) {
-            return nil;
-        }
-    }
-    
-    return path;
+	NSMutableString *path = [NSMutableString new];
+	NSURL *documentPath = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+	[path appendString: documentPath.path];
+	[path appendString:@"/Images/"];
+	
+	if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+		NSError *error;
+		[[NSFileManager defaultManager] createDirectoryAtPath:path withIntermediateDirectories:NO attributes:nil error:&error];
+		
+		if (error) {
+			return nil;
+		}
+	}
+	
+	return path;
 }
 
 @end

--- a/TGCameraViewController/Classes/Helper/TGAssetsLibrary.m
+++ b/TGCameraViewController/Classes/Helper/TGAssetsLibrary.m
@@ -164,7 +164,7 @@
 		return;
 	}
 	
-	NSURL *assetURL = [NSURL URLWithString: filePath];
+	NSURL *assetURL = [NSURL fileURLWithPath: filePath];
 	
 	resultBlock(assetURL);
 }


### PR DESCRIPTION
Hi, I posted an issue yesterday, and then decided to take a look at why I have the problem. I found some issues(sorry if I misunderstood your code purpose) and "fixed" the following:

1. Refactored the way to get directory by using NSFileManager, which is recommended by Apple
2. Only tried to create the image directory when the directory does NOT exist.
3. Use NSFileManager to save the image to documents/Images, and trigger failure block if writing is not successful.
4. Init assetURL with NSURL(fileURLWithPath:) so that the returned url can be used directly for loading the image