### PR TITLE
Verify delegate responds to cameraDidSavePhotoAtPath before calling.

### DIFF
--- a/TGCameraViewController/Classes/Control/TGPhotoViewController.m
+++ b/TGCameraViewController/Classes/Control/TGPhotoViewController.m
@@ -147,7 +147,9 @@ static NSString* const kTGCacheVignetteKey = @"TGCacheVignetteKey";
         
         void (^saveJPGImageAtDocumentDirectory)(UIImage *) = ^(UIImage *photo) {
             [library saveJPGImageAtDocumentDirectory:_photo resultBlock:^(NSURL *assetURL) {
-                [_delegate cameraDidSavePhotoAtPath:assetURL];
+                if ([_delegate respondsToSelector:@selector(cameraDidSavePhotoAtPath:)]) {
+                    [_delegate cameraDidSavePhotoAtPath:assetURL];
+                }
             } failureBlock:^(NSError *error) {
                 if ([_delegate respondsToSelector:@selector(cameraDidSavePhotoWithError:)]) {
                     [_delegate cameraDidSavePhotoWithError:error];


### PR DESCRIPTION
TGCameraViewController can sometimes call cameraDidSavePhotoAtPath
on its delegate, even though the method is marked as optional. This can
cause `NSInvalidArgumentException` errors to be thrown unless that method
is implemented (even as a no-op) in the delegate.