### PR TITLE
Add option to use the original photo aspect instead of 1:1

### DIFF
--- a/Example/TGInitialViewController.m
+++ b/Example/TGInitialViewController.m
@@ -31,16 +31,19 @@
     //[TGCameraColor setTintColor: [UIColor greenColor]];
     
     // save image to album
-    [TGCamera setOption:kTGCameraOptionSaveImageToAlbum value:[NSNumber numberWithBool:YES]];
+    [TGCamera setOption:kTGCameraOptionSaveImageToAlbum value:@YES];
+    
+    // use the original image aspect instead of square
+    [TGCamera setOption:kTGCameraOptionUseOriginalAspect value:@YES];
     
     // hide switch camera button
-    //[TGCamera setOption:kTGCameraOptionHiddenToggleButton value:[NSNumber numberWithBool:YES]];
+    //[TGCamera setOption:kTGCameraOptionHiddenToggleButton value:@YES];
     
     // hide album button
-    //[TGCamera setOption:kTGCameraOptionHiddenAlbumButton value:[NSNumber numberWithBool:YES]];
+    //[TGCamera setOption:kTGCameraOptionHiddenAlbumButton value:@YES;
     
     // hide filter button
-    //[TGCamera setOption:kTGCameraOptionHiddenFilterButton value:[NSNumber numberWithBool:YES]];
+    //[TGCamera setOption:kTGCameraOptionHiddenFilterButton value:@YES];
 
     
     _photoView.clipsToBounds = YES;

--- a/ExampleSwift/TGInitialViewController.swift
+++ b/ExampleSwift/TGInitialViewController.swift
@@ -19,6 +19,9 @@ class TGInitialViewController: UIViewController, TGCameraDelegate {
         
         // save image to album
         TGCamera.setOption(kTGCameraOptionSaveImageToAlbum, value: true)
+
+        // use the standard image aspect instead of square
+        TGCamera.setOption(kTGCameraOptionUseStandardAspect, value: true)
         
         // hide switch camera button
         //TGCamera.setOption(kTGCameraOptionHiddenToggleButton, value: true)

--- a/ExampleSwift/TGInitialViewController.swift
+++ b/ExampleSwift/TGInitialViewController.swift
@@ -20,8 +20,8 @@ class TGInitialViewController: UIViewController, TGCameraDelegate {
         // save image to album
         TGCamera.setOption(kTGCameraOptionSaveImageToAlbum, value: true)
 
-        // use the standard image aspect instead of square
-        TGCamera.setOption(kTGCameraOptionUseStandardAspect, value: true)
+        // use the original image aspect instead of square
+        //TGCamera.setOption(kTGCameraOptionUseOriginalAspect, value: true)
         
         // hide switch camera button
         //TGCamera.setOption(kTGCameraOptionHiddenToggleButton, value: true)

--- a/README.md
+++ b/README.md
@@ -199,9 +199,10 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
 |Option|Type|Default|Description|
 |:-:|:-:|:-:|:-:|
 |kTGCameraOptionHiddenToggleButton|NSNumber (YES/NO)|NO|Displays or hides the button that switches between the front and rear camera|
-|kTGCameraOptionHiddenAlbumButton|NSNumber (YES/NO)|NO|Displays or hides the button that allows the user to select a photo from his/her album|
-|kTGCameraOptionHiddenFilterButton|NSNumber (YES/NO)|NO|Displays or hides the button that allos the user to filter his/her photo|
+|kTGCameraOptionHiddenAlbumButton|NSNumber (YES/NO)|NO|Displays or hides the button that allows the user to select a photo from their album|
+|kTGCameraOptionHiddenFilterButton|NSNumber (YES/NO)|NO|Displays or hides the button that allos the user to filter their photo|
 |kTGCameraOptionSaveImageToAlbum|NSNumber (YES/NO)|NO|Save or not the photo in the camera roll|
+|kTGCameraOptionUseOriginalAspect|NSNumber (YES/NO)|NO|Use the original aspect instead of cropping the image to a square|
 
 ```obj-c
 #import "TGCamera.h"
@@ -211,10 +212,10 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
 - (void)viewDidLoad
 {
     //...
-    [TGCamera setOption:kTGCameraOptionHiddenToggleButton value:[NSNumber numberWithBool:YES]];
-    [TGCamera setOption:kTGCameraOptionHiddenAlbumButton value:[NSNumber numberWithBool:YES]];
-    [TGCamera setOption:kTGCameraOptionHiddenFilterButton value:[NSNumber numberWithBool:YES]];
-    [TGCamera setOption:kTGCameraOptionSaveImageToAlbum value:[NSNumber numberWithBool:YES]];
+    [TGCamera setOption:kTGCameraOptionHiddenToggleButton value:@YES];
+    [TGCamera setOption:kTGCameraOptionHiddenAlbumButton value:@YES];
+    [TGCamera setOption:kTGCameraOptionHiddenFilterButton value:@YES];
+    [TGCamera setOption:kTGCameraOptionSaveImageToAlbum value:@YES];
     //...
 }
 

--- a/TGCameraViewController/Classes/Control/TGCameraViewController.m
+++ b/TGCameraViewController/Classes/Control/TGCameraViewController.m
@@ -104,7 +104,7 @@
         _albumButton.hidden = YES;
     }
 
-    if ([[TGCamera getOption:kTGCameraOptionUseStandardAspect] boolValue] == YES) {
+    if ([[TGCamera getOption:kTGCameraOptionUseOriginalAspect] boolValue] == YES) {
         _bottomViewHeightFixed.active = YES;
         _captureViewAspect.active = NO;
     } else {
@@ -254,6 +254,13 @@
     UIDeviceOrientation deviceOrientation = [[UIDevice currentDevice] orientation];
     AVCaptureVideoOrientation videoOrientation = [self videoOrientationForDeviceOrientation:deviceOrientation];
     
+    CGSize cropSize;
+    if ([[TGCamera getOption:kTGCameraOptionUseOriginalAspect] boolValue] == YES) {
+        cropSize = CGSizeZero;
+    } else {
+        cropSize = _captureView.frame.size;
+    }
+    
     dispatch_group_t group = dispatch_group_create();
     __block UIImage *photo;
     
@@ -263,7 +270,7 @@
     }];
     
     dispatch_group_enter(group);
-    [_camera takePhotoWithCaptureView:_captureView videoOrientation:videoOrientation cropSize:_captureView.frame.size completion:^(UIImage *_photo) {
+    [_camera takePhotoWithCaptureView:_captureView videoOrientation:videoOrientation cropSize:cropSize completion:^(UIImage *_photo) {
         photo = _photo;
         dispatch_group_leave(group);
     }];

--- a/TGCameraViewController/Classes/Control/TGCameraViewController.m
+++ b/TGCameraViewController/Classes/Control/TGCameraViewController.m
@@ -48,7 +48,10 @@
 @property (strong, nonatomic) IBOutlet TGCameraSlideView *slideDownView;
 
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *topViewHeight;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *bottomViewHeightFixed;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *bottomViewHeightFill;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *toggleButtonWidth;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *captureViewAspect;
 
 @property (strong, nonatomic) TGCamera *camera;
 @property (nonatomic) BOOL wasLoaded;
@@ -86,14 +89,11 @@
     
     NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
     if (devices.count > 1) {
-        
         if ([[TGCamera getOption:kTGCameraOptionHiddenToggleButton] boolValue] == YES) {
             _toggleButton.hidden = YES;
             _toggleButtonWidth.constant = 0;
         }
-    }
-    else {
-        
+    } else {  
         if ([[TGCamera getOption:kTGCameraOptionHiddenToggleButton] boolValue] == YES) {
             _toggleButton.hidden = YES;
             _toggleButtonWidth.constant = 0;
@@ -102,6 +102,13 @@
     
     if ([[TGCamera getOption:kTGCameraOptionHiddenAlbumButton] boolValue] == YES) {
         _albumButton.hidden = YES;
+    }
+
+    if ([[TGCamera getOption:kTGCameraOptionUseStandardAspect] boolValue] == YES) {
+        _bottomViewHeightFixed.active = YES;
+        _captureViewAspect.active = NO;
+    } else {
+        _bottomViewHeightFixed.active = NO;
     }
     
     [_albumButton.layer setCornerRadius:10.f];

--- a/TGCameraViewController/Classes/Helper/TGCamera.h
+++ b/TGCameraViewController/Classes/Helper/TGCamera.h
@@ -31,7 +31,7 @@
 #define kTGCameraOptionHiddenAlbumButton @"TGCameraOptionHiddenAlbumButton"
 #define kTGCameraOptionHiddenFilterButton @"TGCameraOptionHiddenFilterButton"
 #define kTGCameraOptionSaveImageToAlbum @"TGCameraOptionSaveImageToAlbum"
-#define kTGCameraOptionUseStandardAspect @"kTGCameraOptionUseStandardAspect"
+#define kTGCameraOptionUseOriginalAspect @"kTGCameraOptionUseOriginalAspect"
 
 @protocol TGCameraDelegate;
 

--- a/TGCameraViewController/Classes/Helper/TGCamera.h
+++ b/TGCameraViewController/Classes/Helper/TGCamera.h
@@ -27,15 +27,13 @@
 @import AVFoundation;
 @import UIKit;
 
-
 #define kTGCameraOptionHiddenToggleButton @"TGCameraOptionHiddenToggleButton"
 #define kTGCameraOptionHiddenAlbumButton @"TGCameraOptionHiddenAlbumButton"
 #define kTGCameraOptionHiddenFilterButton @"TGCameraOptionHiddenFilterButton"
 #define kTGCameraOptionSaveImageToAlbum @"TGCameraOptionSaveImageToAlbum"
+#define kTGCameraOptionUseStandardAspect @"kTGCameraOptionUseStandardAspect"
 
 @protocol TGCameraDelegate;
-
-
 
 @interface TGCamera : NSObject
 

--- a/TGCameraViewController/Classes/Helper/TGCameraShot.m
+++ b/TGCameraViewController/Classes/Helper/TGCameraShot.m
@@ -61,8 +61,10 @@
         if (imageDataSampleBuffer != NULL) {
             NSData *imageData = [AVCaptureStillImageOutput jpegStillImageNSDataRepresentation:imageDataSampleBuffer];
             UIImage *image = [UIImage imageWithData:imageData];
-            UIImage *croppedImage = [weakSelf cropImage:image withCropSize:cropSize];
-            completion(croppedImage);
+            if (!CGSizeEqualToSize(cropSize, CGSizeZero)) {
+                image = [weakSelf cropImage:image withCropSize:cropSize];
+            }
+            completion(image);
         }
     }];
 }

--- a/TGCameraViewController/Classes/View/Base.lproj/TGCameraViewController.xib
+++ b/TGCameraViewController/Classes/View/Base.lproj/TGCameraViewController.xib
@@ -1,9 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TGCameraViewController">
@@ -12,7 +15,10 @@
                 <outlet property="albumButton" destination="wxI-gO-dPX" id="WtA-c8-1cs"/>
                 <outlet property="bottomLeftView" destination="2rS-OA-lDQ" id="3Tj-6s-eEi"/>
                 <outlet property="bottomRightView" destination="HFV-tF-409" id="gvx-Rz-7bX"/>
+                <outlet property="bottomViewHeightFill" destination="4nO-Oz-3L8" id="4e5-kx-BBG"/>
+                <outlet property="bottomViewHeightFixed" destination="Oab-eT-CvB" id="HkQ-tz-mnx"/>
                 <outlet property="captureView" destination="dIq-rQ-gzr" id="F4T-QP-lPu"/>
+                <outlet property="captureViewAspect" destination="jHI-RV-Jf8" id="SMR-2B-cP7"/>
                 <outlet property="closeButton" destination="O3k-MF-E1l" id="WpI-xb-eE2"/>
                 <outlet property="flashButton" destination="p7O-pE-Mp0" id="Tqo-vg-CGw"/>
                 <outlet property="gridButton" destination="Nol-dD-ETh" id="tfG-QF-CbC"/>
@@ -30,18 +36,18 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="820"/>
+            <rect key="frame" x="0.0" y="0.0" width="792" height="820"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dit-c7-IZk" userLabel="Top View">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="60"/>
-                    <color key="backgroundColor" red="0.1176470588" green="0.1176470588" blue="0.1176470588" alpha="1" colorSpace="calibratedRGB"/>
+                    <rect key="frame" x="0.0" y="0.0" width="792" height="50"/>
+                    <color key="backgroundColor" red="0.1176470588" green="0.1176470588" blue="0.1176470588" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="60" id="0mu-lN-Lkb"/>
+                        <constraint firstAttribute="height" constant="50" id="0mu-lN-Lkb"/>
                     </constraints>
                 </view>
-                <view multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dIq-rQ-gzr" userLabel="Capture View">
-                    <rect key="frame" x="0.0" y="60" width="600" height="600"/>
+                <view multipleTouchEnabled="YES" contentMode="scaleToFill" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="dIq-rQ-gzr" userLabel="Capture View">
+                    <rect key="frame" x="0.0" y="50" width="792" height="620"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CameraDetail" translatesAutoresizingMaskIntoConstraints="NO" id="ljD-PV-2sR" userLabel="Top Left">
                             <rect key="frame" x="0.0" y="0.0" width="58" height="58"/>
@@ -51,25 +57,25 @@
                             </constraints>
                         </imageView>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CameraDetail" translatesAutoresizingMaskIntoConstraints="NO" id="umk-ea-F3l" userLabel="Top Right">
-                            <rect key="frame" x="542" y="0.0" width="58" height="58"/>
+                            <rect key="frame" x="734" y="0.0" width="58" height="58"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="58" id="3kF-VG-r1w"/>
                                 <constraint firstAttribute="height" constant="58" id="fo1-rR-IP5"/>
                             </constraints>
                         </imageView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xFF-75-cke" userLabel="Separator View">
-                            <rect key="frame" x="0.0" y="299" width="600" height="2"/>
+                            <rect key="frame" x="0.0" y="309" width="792" height="2"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GxH-mC-xM3" userLabel="Top Separator View">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
-                                    <color key="backgroundColor" red="0.078431372550000003" green="0.078431372550000003" blue="0.078431372550000003" alpha="1" colorSpace="calibratedRGB"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="792" height="1"/>
+                                    <color key="backgroundColor" red="0.078431372550000003" green="0.078431372550000003" blue="0.078431372550000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="iTp-J7-sUN"/>
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yg1-A1-fum" userLabel="Button Separator View">
-                                    <rect key="frame" x="0.0" y="1" width="600" height="1"/>
-                                    <color key="backgroundColor" white="1" alpha="0.050000000000000003" colorSpace="calibratedWhite"/>
+                                    <rect key="frame" x="0.0" y="1" width="792" height="1"/>
+                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.050000000000000003" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="ACL-FR-naP"/>
                                     </constraints>
@@ -86,21 +92,21 @@
                             </constraints>
                         </view>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CameraDetail" translatesAutoresizingMaskIntoConstraints="NO" id="2rS-OA-lDQ" userLabel="Bottom Left">
-                            <rect key="frame" x="0.0" y="542" width="58" height="58"/>
+                            <rect key="frame" x="0.0" y="562" width="58" height="58"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="58" id="m8b-0G-cS3"/>
                                 <constraint firstAttribute="width" constant="58" id="r8H-hS-XjU"/>
                             </constraints>
                         </imageView>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CameraDetail" translatesAutoresizingMaskIntoConstraints="NO" id="HFV-tF-409" userLabel="Bottom Right">
-                            <rect key="frame" x="542" y="542" width="58" height="58"/>
+                            <rect key="frame" x="734" y="562" width="58" height="58"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="58" id="Hf0-do-VjA"/>
                                 <constraint firstAttribute="height" constant="58" id="eM7-tr-8mw"/>
                             </constraints>
                         </imageView>
                     </subviews>
-                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <gestureRecognizers/>
                     <constraints>
                         <constraint firstItem="umk-ea-F3l" firstAttribute="top" secondItem="dIq-rQ-gzr" secondAttribute="top" id="1zC-th-e2x"/>
@@ -112,7 +118,7 @@
                         <constraint firstItem="2rS-OA-lDQ" firstAttribute="leading" secondItem="dIq-rQ-gzr" secondAttribute="leading" id="cyk-bG-M9K"/>
                         <constraint firstAttribute="centerY" secondItem="xFF-75-cke" secondAttribute="centerY" id="fOl-Ic-N0Q"/>
                         <constraint firstAttribute="bottom" secondItem="2rS-OA-lDQ" secondAttribute="bottom" id="fjD-cR-2nv"/>
-                        <constraint firstAttribute="width" secondItem="dIq-rQ-gzr" secondAttribute="height" multiplier="1:1" priority="999" id="rY0-Cn-lea"/>
+                        <constraint firstAttribute="width" secondItem="dIq-rQ-gzr" secondAttribute="height" multiplier="1:1" priority="999" id="jHI-RV-Jf8"/>
                         <constraint firstItem="ljD-PV-2sR" firstAttribute="leading" secondItem="dIq-rQ-gzr" secondAttribute="leading" id="rxy-AI-9fw"/>
                         <constraint firstItem="xFF-75-cke" firstAttribute="leading" secondItem="dIq-rQ-gzr" secondAttribute="leading" id="vve-NH-MbK"/>
                     </constraints>
@@ -121,10 +127,10 @@
                     </connections>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ni6-M2-hWT" userLabel="Actions View">
-                    <rect key="frame" x="0.0" y="660" width="600" height="50"/>
+                    <rect key="frame" x="0.0" y="670" width="792" height="50"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nol-dD-ETh" userLabel="Grid" customClass="TGTintedButton">
-                            <rect key="frame" x="162" y="5" width="50" height="40"/>
+                            <rect key="frame" x="258" y="5" width="50" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="40" id="Aub-V9-12O"/>
                                 <constraint firstAttribute="width" constant="50" id="ivk-GF-mOZ"/>
@@ -135,7 +141,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJG-N5-BnZ" userLabel="Toggle" customClass="TGTintedButton">
-                            <rect key="frame" x="275" y="5" width="50" height="40"/>
+                            <rect key="frame" x="371" y="5" width="50" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="50" id="6Yw-v5-k8c"/>
                                 <constraint firstAttribute="height" constant="40" id="XBx-hh-hmO"/>
@@ -146,7 +152,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p7O-pE-Mp0" userLabel="Flash" customClass="TGTintedButton">
-                            <rect key="frame" x="388" y="5" width="50" height="40"/>
+                            <rect key="frame" x="484" y="5" width="50" height="40"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="50" id="6QJ-EO-jQZ"/>
                                 <constraint firstAttribute="height" constant="40" id="iqh-0F-jLz"/>
@@ -157,7 +163,7 @@
                             </connections>
                         </button>
                     </subviews>
-                    <color key="backgroundColor" red="0.1176470588" green="0.1176470588" blue="0.1176470588" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.1176470588" green="0.1176470588" blue="0.1176470588" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstItem="p7O-pE-Mp0" firstAttribute="leading" secondItem="WJG-N5-BnZ" secondAttribute="trailing" constant="63" id="1q8-DG-v1g"/>
                         <constraint firstItem="WJG-N5-BnZ" firstAttribute="leading" secondItem="Nol-dD-ETh" secondAttribute="trailing" constant="63" id="41d-NA-H1H"/>
@@ -168,11 +174,11 @@
                         <constraint firstAttribute="centerY" secondItem="p7O-pE-Mp0" secondAttribute="centerY" id="rwx-2G-cxy"/>
                     </constraints>
                 </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rJ9-I8-VJI" userLabel="Bottom View">
-                    <rect key="frame" x="0.0" y="710" width="600" height="110"/>
+                <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="rJ9-I8-VJI" userLabel="Bottom View">
+                    <rect key="frame" x="0.0" y="720" width="792" height="100"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O3k-MF-E1l" userLabel="Close" customClass="TGTintedButton">
-                            <rect key="frame" x="20" y="15" width="80" height="80"/>
+                            <rect key="frame" x="20" y="10" width="80" height="80"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="80" id="cgU-fk-MtB"/>
                                 <constraint firstAttribute="width" constant="80" id="xhg-SH-0Q3"/>
@@ -183,9 +189,9 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wtQ-Dg-G3i" userLabel="Shot" customClass="TGTintedButton">
-                            <rect key="frame" x="261" y="16" width="78" height="78"/>
+                            <rect key="frame" x="357" y="11" width="78" height="78"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="78" id="HAC-kq-tli"/>
+                                <constraint firstAttribute="width" secondItem="wtQ-Dg-G3i" secondAttribute="height" multiplier="1:1" id="Ci1-5o-Y1A"/>
                                 <constraint firstAttribute="height" constant="78" id="Hud-wO-9uR"/>
                             </constraints>
                             <state key="normal" image="CameraShot"/>
@@ -194,7 +200,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wxI-gO-dPX" userLabel="Album" customClass="TGTintedButton">
-                            <rect key="frame" x="500" y="15" width="80" height="80"/>
+                            <rect key="frame" x="692" y="10" width="80" height="80"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="80" id="Qit-id-URc"/>
                                 <constraint firstAttribute="width" constant="80" id="twe-nl-2AZ"/>
@@ -205,19 +211,23 @@
                             </connections>
                         </button>
                     </subviews>
-                    <color key="backgroundColor" red="0.078431372549019607" green="0.078431372549019607" blue="0.078431372549019607" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.078431372549019607" green="0.078431372549019607" blue="0.078431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="centerY" secondItem="wtQ-Dg-G3i" secondAttribute="centerY" id="02I-TO-eyD"/>
+                        <constraint firstItem="wtQ-Dg-G3i" firstAttribute="top" relation="greaterThanOrEqual" secondItem="rJ9-I8-VJI" secondAttribute="top" constant="10" id="4cm-iP-cYP"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="100" id="4nO-Oz-3L8"/>
                         <constraint firstAttribute="centerY" secondItem="O3k-MF-E1l" secondAttribute="centerY" id="AlZ-MU-XJk"/>
                         <constraint firstAttribute="centerY" secondItem="wxI-gO-dPX" secondAttribute="centerY" id="Cv6-as-QDW"/>
+                        <constraint firstAttribute="height" constant="100" id="Oab-eT-CvB"/>
                         <constraint firstAttribute="centerX" secondItem="wtQ-Dg-G3i" secondAttribute="centerX" id="UII-sp-ZJm"/>
+                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="wtQ-Dg-G3i" secondAttribute="bottom" constant="10" id="XG3-c3-nnN"/>
                         <constraint firstItem="O3k-MF-E1l" firstAttribute="leading" secondItem="rJ9-I8-VJI" secondAttribute="leading" constant="20" id="h2u-nH-RSf"/>
                         <constraint firstAttribute="trailing" secondItem="wxI-gO-dPX" secondAttribute="trailing" constant="20" id="xUB-TR-bow"/>
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" red="0.1176470588" green="0.1176470588" blue="0.1176470588" alpha="1" colorSpace="calibratedRGB"/>
-            <color key="tintColor" red="1" green="0.35686275362968445" blue="0.0039215688593685627" alpha="1" colorSpace="deviceRGB"/>
+            <color key="backgroundColor" red="0.1176470588" green="0.1176470588" blue="0.1176470588" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="tintColor" red="0.98755216598510742" green="0.26285848021507263" blue="0.032961577177047729" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="rJ9-I8-VJI" secondAttribute="trailing" id="354-YR-Y3x"/>
                 <constraint firstItem="dIq-rQ-gzr" firstAttribute="top" secondItem="dit-c7-IZk" secondAttribute="bottom" id="5ZP-oL-R1c"/>
@@ -235,7 +245,7 @@
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="833" y="280"/>
+            <point key="canvasLocation" x="808" y="200"/>
         </view>
         <view contentMode="scaleToFill" id="vJp-kA-okD" customClass="TGCameraSlideUpView">
             <rect key="frame" x="0.0" y="0.0" width="600" height="225"/>
@@ -243,14 +253,14 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HQ4-27-y2g" userLabel="Separator View">
                     <rect key="frame" x="0.0" y="224" width="600" height="1"/>
-                    <color key="backgroundColor" red="0.078431372550000003" green="0.078431372550000003" blue="0.078431372550000003" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.078431372550000003" green="0.078431372550000003" blue="0.078431372550000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="HY2-Sb-rlR"/>
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="1" colorSpace="calibratedRGB"/>
-            <color key="tintColor" red="1" green="0.35686275360000003" blue="0.0039215688589999999" alpha="1" colorSpace="deviceRGB"/>
+            <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="tintColor" red="0.98755216598510742" green="0.26285848021507263" blue="0.032961577177047729" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="HQ4-27-y2g" firstAttribute="leading" secondItem="vJp-kA-okD" secondAttribute="leading" id="GqW-ZD-APZ"/>
                 <constraint firstAttribute="trailing" secondItem="HQ4-27-y2g" secondAttribute="trailing" id="Hnf-2P-GD4"/>
@@ -258,7 +268,7 @@
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="1484" y="-17.5"/>
+            <point key="canvasLocation" x="1577" y="-97"/>
         </view>
         <view contentMode="scaleToFill" id="Czb-nz-m44" customClass="TGCameraSlideDownView">
             <rect key="frame" x="0.0" y="0.0" width="600" height="225"/>
@@ -266,14 +276,14 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wsO-7U-Imk" userLabel="Separator View">
                     <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
-                    <color key="backgroundColor" white="1" alpha="0.050000000000000003" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.050000000000000003" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="RKR-Z9-Lco"/>
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="1" colorSpace="calibratedRGB"/>
-            <color key="tintColor" red="1" green="0.35686275360000003" blue="0.0039215688589999999" alpha="1" colorSpace="deviceRGB"/>
+            <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="tintColor" red="0.98755216598510742" green="0.26285848021507263" blue="0.032961577177047729" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="wsO-7U-Imk" firstAttribute="top" secondItem="Czb-nz-m44" secondAttribute="top" id="8ye-9a-LYK"/>
                 <constraint firstItem="wsO-7U-Imk" firstAttribute="leading" secondItem="Czb-nz-m44" secondAttribute="leading" id="9ZZ-vg-AT1"/>
@@ -281,7 +291,7 @@
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="1484" y="254.5"/>
+            <point key="canvasLocation" x="1577" y="200"/>
         </view>
         <tapGestureRecognizer id="8lp-h9-4Ub">
             <connections>


### PR DESCRIPTION
By setting `kTGCameraOptionUseOriginalAspect` to `YES` the lib should take photos using the original aspect from the camera instead of cropping it to a square.